### PR TITLE
add dataset metrics to summary message

### DIFF
--- a/src/summaries.proto
+++ b/src/summaries.proto
@@ -2,6 +2,9 @@ syntax = "proto3";
 
 import "messages.proto";
 
+import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
+
 option java_package = "com.whylogs.core.message";
 option java_outer_classname = "Summaries";
 option java_multiple_files = true;
@@ -98,6 +101,37 @@ message ColumnSummary {
 message DatasetSummary {
   DatasetProperties properties = 1;
   map<string, ColumnSummary> columns = 2;
+  ModelSummary model = 3;
+}
+
+message ModelSummary {
+  MetricsSummary metrics = 1;
+}
+
+message MetricsSummary {
+  ModelType model_type = 1;
+  ROCCurve roc_fpr_tpr = 2;
+  RecallCurve recall_prec = 3;
+  ConfusionMatrix confusion_matrix = 4;
+}
+
+message ConfusionMatrix {
+  repeated string labels = 1;
+  string target_field = 2;
+  string predictions_field=3;
+  string score_field=4;
+  repeated google.protobuf.ListValue counts = 5;  // e.g. [[33, 6], [11, 27]]
+}
+
+message ROCCurve {
+  // e.g.   "values": [ [1, 0.42857],  [1, 0.42857], ... ]
+  repeated google.protobuf.ListValue values = 1;
+}
+
+
+message RecallCurve {
+  // e.g.   "values": [ [1, 1],  [1, 1], ... ]
+  repeated google.protobuf.ListValue values = 1;
 }
 
 message DatasetSummaries {


### PR DESCRIPTION
- Add protobuf definitions for derived metrics in dataset summary.
- Based on [add_metrics_to_summary](https://gitlab.com/whylabs/datascience/whylogs-mockingbird/-/blob/mainline/mockingbird/merger/compute_metrics.py#L448-478) in mockingbird.
- Unit test added to whylogs python repo.